### PR TITLE
4 Move msg become one msg: Move (Maybe Direction)

### DIFF
--- a/src/touchInputManager.js
+++ b/src/touchInputManager.js
@@ -71,8 +71,10 @@ TouchInputManager.prototype.listen = function () {
     var absDy = Math.abs(dy);
 
     if (Math.max(absDx, absDy) > 10) {
-      var direction = absDx > absDy ? (dx > 0 ? "ArrowRight" : "ArrowLeft") : (dy > 0 ? "ArrowDown" : "ArrowUp");
-      self.app.ports.swipeDirectionArrow.send(direction);
+      var direction = absDx > absDy ?
+        (dx > 0 ? "ArrowRight" : "ArrowLeft") :
+        (dy > 0 ? "ArrowDown" : "ArrowUp");
+      self.app.ports.swipeDirectionArrow.send({ key: direction });
 
     }
   });


### PR DESCRIPTION
4 Move msg become one msg: Move (Maybe Direction)

The keyboard and swipe events received through subscriptions are
turned into Maybe Direction values which are now passed as an argument
to a single Move msg.

This also allows removal of the NoOp msg.

The data arriving at the incoming port swipeDirectionArrow
is now a payload almost identical to that produced
by Events.onKeyDown:

  { key: <arrow-key-string> }