### PR TITLE
can't get decode fail to work when decoding from port

### DIFF
--- a/src/touchInputManager.js
+++ b/src/touchInputManager.js
@@ -71,8 +71,10 @@ TouchInputManager.prototype.listen = function () {
     var absDy = Math.abs(dy);
 
     if (Math.max(absDx, absDy) > 10) {
-      var direction = absDx > absDy ? (dx > 0 ? "ArrowRight" : "ArrowLeft") : (dy > 0 ? "ArrowDown" : "ArrowUp");
-      self.app.ports.swipeDirectionArrow.send(direction);
+      var direction = absDx > absDy ?
+        (dx > 0 ? "ArrowRight" : "ArrowLeft") :
+        (dy > 0 ? "ArrowDown" : "ArrowUp");
+      self.app.ports.swipeDirectionArrow.send({ key: direction });
 
     }
   });


### PR DESCRIPTION
cancel Events.onKeyDown decoding w/Decode.fail

Use Decode.fail to short-circuit the Arrow key decoding on the Events.onKeyDown
subscription. This avoids having to explicitly handle the case where a key event
occurs that is not a direction arrow and generate a NoOp Msg. Using Decode.fail
no message is generated at all.

Haven't figured out any way to use same technique in the incoming port
swipeDirectionArrow which is processed by handleSwipe in the associated
subscription.

The swipeDirectionArrow is now a payload almost identical to that
produced by Events.onKeyDown:

  { key: <arrow-key-string> }